### PR TITLE
Fix retry action in stock list screen

### DIFF
--- a/app/src/main/java/com/hzdawoud/fetchlt/presentation/ui/EodDataListScreen.kt
+++ b/app/src/main/java/com/hzdawoud/fetchlt/presentation/ui/EodDataListScreen.kt
@@ -62,7 +62,10 @@ fun EodListScreen(
                 is StockListUiState.Error -> {
                     ErrorView(
                         modifier = Modifier.align(Alignment.Center),
-                        onRetry = { viewModel.readStockSymbolsFromFile(context) }
+                        onRetry = {
+                            val tickers = viewModel.readStockSymbolsFromFile(context)
+                            viewModel.fetchStocks(tickers)
+                        }
                     )
                 }
 


### PR DESCRIPTION
## Summary
- correct retry handler in `EodDataListScreen`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6846a05e2cd083208a8b52eb536df307